### PR TITLE
Resolve problem with version of liip imagine bundle 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=5.3.3",
         "symfony/framework-bundle": "~2.3",
         "symfony/twig-bundle": "~2.3",
-        "liip/imagine-bundle": "dev-master",
+        "liip/imagine-bundle": "0.*",
         "fsi/form-extensions-bundle": "1.0.*",
         "fsi/admin-bundle" : "1.0.*",
         "fsi/gallery-bundle": "dev-master"


### PR DESCRIPTION
This commit resolves problem with dependencies for admin-gallery-bundle
problem is caused by different versions of liip-imagine-bundle in admin-gallery and admin-gallery-bundle.
[code]
Problem 1
    - Installation request for fsi/admin-gallery-bundle 1.0.*@dev -> satisfiable by fsi/admin-gallery-bundle[1.0.x-dev].
    - fsi/admin-gallery-bundle 1.0.x-dev requires liip/imagine-bundle dev-master -> no matching package found.
[/code]
